### PR TITLE
Readme fix

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -10,4 +10,4 @@ The following things make this library attractive to create unittests
 * Works with the updater from telegram.ext
 * Generatorclasses to easily create Users, Chats and Updates.
 
-Read the [documentation](https://readthedocs.org/projects/ptbtestsuite/badge/?version=master) for further reading and check out the examples.
+Read the [documentation](http://ptbtestsuite.readthedocs.io/en/master/?badge=master) for further reading and check out the examples.


### PR DESCRIPTION
Fixes a broken link, namely the documentation link in the text.

The old link would open a page with only the badge on it. Now is the same as the target of the doc-badge at the top.