### PR TITLE
Adapting code to python-telegram-bot 8.1.1

### DIFF
--- a/ptbtest/mockbot.py
+++ b/ptbtest/mockbot.py
@@ -27,6 +27,7 @@ import warnings
 import time
 
 from telegram import (User, ReplyMarkup, TelegramObject)
+from telegram.utils.request import Request
 from telegram.error import TelegramError
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -68,6 +69,7 @@ class Mockbot(TelegramObject):
         from .chatgenerator import ChatGenerator
         self.mg = MessageGenerator(bot=self)
         self.cg = ChatGenerator()
+        self.request = Request()
 
     @property
     def sent_messages(self):
@@ -190,7 +192,7 @@ class Mockbot(TelegramObject):
         return decorator
 
     def getMe(self, timeout=None, **kwargs):
-        self.bot = User(0, "Mockbot", last_name="Bot", username=self._username)
+        self.bot = User(0, "Mockbot", last_name="Bot", is_bot=True, username=self._username)
         return self.bot
 
     @message

--- a/ptbtest/usergenerator.py
+++ b/ptbtest/usergenerator.py
@@ -42,7 +42,7 @@ class UserGenerator(PtbGenerator):
         PtbGenerator.__init__(self)
 
     def get_user(self, first_name=None, last_name=None, username=None,
-                 id=None):
+                 id=None, is_bot=False):
         """
         Returns a telegram.User object with the optionally given name(s) or username
         If any of the arguments are omitted the names will be chosen randomly and the
@@ -66,5 +66,6 @@ class UserGenerator(PtbGenerator):
         return User(
             id or self.gen_id(),
             first_name,
+            is_bot=is_bot,
             last_name=last_name,
             username=username)

--- a/tests/test_Callbackquerygenerator.py
+++ b/tests/test_Callbackquerygenerator.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
+
 import unittest
 
 from ptbtest import (BadBotException, BadCallbackQueryException,

--- a/tests/test_Chatgenerator.py
+++ b/tests/test_Chatgenerator.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
+
 import unittest
 from ptbtest import ChatGenerator
 from ptbtest import UserGenerator

--- a/tests/test_Inlinequerygenerator.py
+++ b/tests/test_Inlinequerygenerator.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
+
 import unittest
 
 from ptbtest.errors import (BadBotException, BadUserException)

--- a/tests/test_Messagegenerator.py
+++ b/tests/test_Messagegenerator.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
 
 import unittest
 

--- a/tests/test_Mockbot.py
+++ b/tests/test_Mockbot.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
 
 import unittest
 
@@ -47,7 +49,7 @@ class TestMockbot(unittest.TestCase):
         dp = updater.dispatcher
         dp.add_handler(CommandHandler("start", start))
         updater.start_polling()
-        user = User(id=1, first_name="test")
+        user = User(id=1, first_name="test", is_bot=False)
         chat = Chat(45, "group")
         message = Message(
             404, user, None, chat, text="/start", bot=self.mockbot)

--- a/tests/test_Usergenerator.py
+++ b/tests/test_Usergenerator.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
+
 import unittest
 
 from ptbtest import UserGenerator


### PR DESCRIPTION
There were only 2 problems on the lib:

* First, the Mockbot must to have a "request" attribute. The value is an object telegram.util.request.Request;
* Second, the User constructor from telegram.User needs a new argument: is_bot. This values defines if the user is a bot or not. When using inside the Mockbot, I set this value to True. On the usergenerator class, I added this variable and set as default False.

I don't know exactly how Travis works, but, to execute the tests here, I need to change the system path on each test class. I made this modifications, but you can change if necessary.

If is everything ok, can you release this lib? I need it on a application that I'm building.