### PR TITLE
Fix "'Mockbot' object has no attribute 'delete_webhook'" error

### DIFF
--- a/ptbtest/mockbot.py
+++ b/ptbtest/mockbot.py
@@ -27,6 +27,7 @@ import warnings
 import time
 
 from telegram import (User, ReplyMarkup, TelegramObject)
+from telegram.utils.request import Request
 from telegram.error import TelegramError
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -68,6 +69,7 @@ class Mockbot(TelegramObject):
         from .chatgenerator import ChatGenerator
         self.mg = MessageGenerator(bot=self)
         self.cg = ChatGenerator()
+        self.request = Request()
 
     @property
     def sent_messages(self):
@@ -190,7 +192,7 @@ class Mockbot(TelegramObject):
         return decorator
 
     def getMe(self, timeout=None, **kwargs):
-        self.bot = User(0, "Mockbot", last_name="Bot", username=self._username)
+        self.bot = User(0, "Mockbot", last_name="Bot", is_bot=True, username=self._username)
         return self.bot
 
     @message

--- a/ptbtest/mockbot.py
+++ b/ptbtest/mockbot.py
@@ -30,6 +30,7 @@ from telegram import (User, ReplyMarkup, TelegramObject)
 from telegram.utils.request import Request
 from telegram.error import TelegramError
 
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
@@ -667,6 +668,9 @@ class Mockbot(TelegramObject):
                    certificate=None,
                    timeout=None,
                    **kwargs):
+        return None
+
+    def delete_webhook(self, timeout=None, **kwargs):
         return None
 
     def leaveChat(self, chat_id, timeout=None, **kwargs):

--- a/ptbtest/usergenerator.py
+++ b/ptbtest/usergenerator.py
@@ -42,7 +42,7 @@ class UserGenerator(PtbGenerator):
         PtbGenerator.__init__(self)
 
     def get_user(self, first_name=None, last_name=None, username=None,
-                 id=None):
+                 id=None, is_bot=False):
         """
         Returns a telegram.User object with the optionally given name(s) or username
         If any of the arguments are omitted the names will be chosen randomly and the
@@ -66,5 +66,6 @@ class UserGenerator(PtbGenerator):
         return User(
             id or self.gen_id(),
             first_name,
+            is_bot=is_bot,
             last_name=last_name,
             username=username)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 from setuptools import find_packages
 
-with codecs.open("readme.rst", "r", "utf-8") as fd:
+with codecs.open("readme.MD", "r", "utf-8") as fd:
 
     setup(
         name='ptbtest',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 from setuptools import find_packages
 
-with codecs.open("readme.MD", "r", "utf-8") as fd:
+with codecs.open("readme.rst", "r", "utf-8") as fd:
 
     setup(
         name='ptbtest',

--- a/tests/test_Callbackquerygenerator.py
+++ b/tests/test_Callbackquerygenerator.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
+
 import unittest
 
 from ptbtest import (BadBotException, BadCallbackQueryException,

--- a/tests/test_Chatgenerator.py
+++ b/tests/test_Chatgenerator.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
+
 import unittest
 from ptbtest import ChatGenerator
 from ptbtest import UserGenerator

--- a/tests/test_Inlinequerygenerator.py
+++ b/tests/test_Inlinequerygenerator.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
+
 import unittest
 
 from ptbtest.errors import (BadBotException, BadUserException)

--- a/tests/test_Messagegenerator.py
+++ b/tests/test_Messagegenerator.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
 
 import unittest
 

--- a/tests/test_Mockbot.py
+++ b/tests/test_Mockbot.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
 
 import unittest
 
@@ -47,7 +49,7 @@ class TestMockbot(unittest.TestCase):
         dp = updater.dispatcher
         dp.add_handler(CommandHandler("start", start))
         updater.start_polling()
-        user = User(id=1, first_name="test")
+        user = User(id=1, first_name="test", is_bot=False)
         chat = Chat(45, "group")
         message = Message(
             404, user, None, chat, text="/start", bot=self.mockbot)

--- a/tests/test_Usergenerator.py
+++ b/tests/test_Usergenerator.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 from __future__ import absolute_import
+from os import sys
+sys.path.append("..")
+
 import unittest
 
 from ptbtest import UserGenerator


### PR DESCRIPTION
Simple fix, create `delete_webhook` method in Mockbot like `set_webhook`.