### PR TITLE
fix typo on test_inlinekeyboard example code line 23

### DIFF
--- a/examples/test_inlinekeyboard.py
+++ b/examples/test_inlinekeyboard.py
@@ -20,7 +20,7 @@ We will skip the start and help callbacks and focus on the callback query.
 """
 class TestInlineKeyboard(unittest.TestCase):
     def setUp(self):
-        # For use within the tests we nee some stuff. Starting with a Mockbot
+        # For use within the tests we need some stuff. Starting with a Mockbot
         self.bot = Mockbot()
         # Some generators for users and chats
         self.cg = ChatGenerator()


### PR DESCRIPTION
Line 23 of test_inlinekeyboard example is acomment that said => # For use within the tests we **nee** some stuff. Starting with a Mockbot
I added the **d** at **need**